### PR TITLE
Support: javascript-node 24 and typescript-node 24

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -610,6 +610,16 @@
                 "Type": "other",
                 "Other": {
                     "Name": "Docker Image: node",
+                    "Version": "24-bookworm",
+                    "DownloadUrl": "https://hub.docker.com/_/node"
+                }
+            }
+        },
+        {
+            "Component": {
+                "Type": "other",
+                "Other": {
+                    "Name": "Docker Image: node",
                     "Version": "22-bookworm",
                     "DownloadUrl": "https://hub.docker.com/_/node"
                 }
@@ -631,6 +641,16 @@
                 "Other": {
                     "Name": "Docker Image: node",
                     "Version": "18-bookworm",
+                    "DownloadUrl": "https://hub.docker.com/_/node"
+                }
+            }
+        },
+        {
+            "Component": {
+                "Type": "other",
+                "Other": {
+                    "Name": "Docker Image: node",
+                    "Version": "24-bullseye",
                     "DownloadUrl": "https://hub.docker.com/_/node"
                 }
             }
@@ -1233,6 +1253,16 @@
                 "Type": "other",
                 "Other": {
                     "Name": "Docker Image: node",
+                    "Version": "24-bookworm",
+                    "DownloadUrl": "https://hub.docker.com/_/node"
+                }
+            }
+        },
+        {
+            "Component": {
+                "Type": "other",
+                "Other": {
+                    "Name": "Docker Image: node",
                     "Version": "22-bookworm",
                     "DownloadUrl": "https://hub.docker.com/_/node"
                 }
@@ -1254,6 +1284,16 @@
                 "Other": {
                     "Name": "Docker Image: node",
                     "Version": "18-bookworm",
+                    "DownloadUrl": "https://hub.docker.com/_/node"
+                }
+            }
+        },
+        {
+            "Component": {
+                "Type": "other",
+                "Other": {
+                    "Name": "Docker Image: node",
+                    "Version": "24-bullseye",
                     "DownloadUrl": "https://hub.docker.com/_/node"
                 }
             }

--- a/src/javascript-node/.devcontainer/Dockerfile
+++ b/src/javascript-node/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-ARG VARIANT=22-bookworm
+ARG VARIANT=24-bookworm
 FROM node:${VARIANT}
 
 ARG USERNAME=node

--- a/src/javascript-node/README.md
+++ b/src/javascript-node/README.md
@@ -9,7 +9,7 @@
 | *Categories* | Core, Languages |
 | *Image type* | Dockerfile |
 | *Published image* | mcr.microsoft.com/devcontainers/javascript-node |
-| *Available image variants* | 22 / 22-bookworm, 20 / 20-bookworm, 18 / 18-bookworm, 20-bullseye, 18-bullseye, ([full list](https://mcr.microsoft.com/v2/devcontainers/javascript-node/tags/list)) |
+| *Available image variants* | 24 / 24-bookworm, 22 / 22-bookworm, 20 / 20-bookworm, 18 / 18-bookworm, 24-bullseye, 22-bullseye, 20-bullseye, ([full list](https://mcr.microsoft.com/v2/devcontainers/javascript-node/tags/list)) |
 | *Published image architecture(s)* | x86-64, arm64/aarch64 for `bookworm`, and `bullseye` variants |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
@@ -20,19 +20,19 @@
 You can directly reference pre-built versions of `Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own  `Dockerfile` to one of the following. An example `Dockerfile` is included in this repository.
 
 - `mcr.microsoft.com/devcontainers/javascript-node` (latest)
+- `mcr.microsoft.com/devcontainers/javascript-node:24` (or `24-bookworm`, `24-bullseye` to pin to an OS version)
 - `mcr.microsoft.com/devcontainers/javascript-node:22` (or `22-bookworm`, `22-bullseye` to pin to an OS version)
 - `mcr.microsoft.com/devcontainers/javascript-node:20` (or `20-bookworm`, `20-bullseye` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/javascript-node:18` (or `18-bookworm`, `18-bullseye` to pin to an OS version)
 
 Refer to [this guide](https://containers.dev/guide/dockerfile) for more details.
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
-- `mcr.microsoft.com/devcontainers/typescript-node:1-22` (or `1-22-bookworm`, `1-22-bullseye`)
-- `mcr.microsoft.com/devcontainers/typescript-node:1.1-22` (or `1.1-22-bookworm`, `1.1-22-bullseye`)
-- `mcr.microsoft.com/devcontainers/typescript-node:1.1.0-22` (or `1.1.0-22-bookworm`, `1.1.0-22-bullseye`)
+- `mcr.microsoft.com/devcontainers/typescript-node:1-24` (or `1-24-bookworm`, `1-24-bullseye`)
+- `mcr.microsoft.com/devcontainers/typescript-node:1.1-24` (or `1.1-24-bookworm`, `1.1-24-bullseye`)
+- `mcr.microsoft.com/devcontainers/typescript-node:1.1.0-24` (or `1.1.0-24-bookworm`, `1.1.0-24-bullseye`)
 
-However, we only do security patching on the latest [non-breaking, in support](https://github.com/devcontainers/images/issues/90) versions of images (e.g. `1-1.0`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
+However, we only do security patching on the latest [non-breaking, in support](https://github.com/devcontainers/images/issues/90) versions of images (e.g. `1-24`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 
 Beyond Node.js and `git`, this image / `Dockerfile` includes `eslint`, `zsh`, [Oh My Zsh!](https://ohmyz.sh/), a non-root `node` user with `sudo` access, and a set of common dependencies for development. [Node Version Manager](https://github.com/nvm-sh/nvm) (`nvm`) is also included in case you need to use a different version of Node.js than the one included in the image.
 

--- a/src/javascript-node/manifest.json
+++ b/src/javascript-node/manifest.json
@@ -1,17 +1,23 @@
 {
 	"version": "1.1.12",
 	"variants": [
+		"24-bookworm",
 		"22-bookworm",
 		"20-bookworm",
 		"18-bookworm",
+		"24-bullseye",
 		"22-bullseye",
 		"20-bullseye",
 		"18-bullseye"
 	],
 	"build": {
-		"latest": "22-bookworm",
+		"latest": "24-bookworm",
 		"rootDistro": "debian",
 		"architectures": {
+			"24-bookworm": [
+				"linux/amd64",
+				"linux/arm64"
+			],
 			"22-bookworm": [
 				"linux/amd64",
 				"linux/arm64"
@@ -21,6 +27,10 @@
 				"linux/arm64"
 			],
 			"18-bookworm": [
+				"linux/amd64",
+				"linux/arm64"
+			],
+			"24-bullseye": [
 				"linux/amd64",
 				"linux/arm64"
 			],
@@ -41,9 +51,12 @@
 			"javascript-node:${VERSION}-${VARIANT}"
 		],
 		"variantTags": {
-			"22-bookworm": [
-				"javascript-node:${VERSION}-22",
+			"24-bookworm": [
+				"javascript-node:${VERSION}-24",
 				"javascript-node:${VERSION}-bookworm"
+			],
+			"22-bookworm": [
+				"javascript-node:${VERSION}-22"
 			],
 			"20-bookworm": [
 				"javascript-node:${VERSION}-20"
@@ -51,7 +64,13 @@
 			"18-bookworm": [
 				"javascript-node:${VERSION}-18"
 			],
+			"24-bullseye": [
+				"javascript-node:${VERSION}-bullseye"
+			],
 			"22-bullseye": [
+				"javascript-node:${VERSION}-bullseye"
+			],
+			"20-bullseye": [
 				"javascript-node:${VERSION}-bullseye"
 			]
 		}

--- a/src/typescript-node/.devcontainer/Dockerfile
+++ b/src/typescript-node/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-ARG VARIANT=22-bookworm
+ARG VARIANT=24-bookworm
 FROM mcr.microsoft.com/devcontainers/javascript-node:1-${VARIANT}
 
 # Install tslint, typescript. eslint is installed by javascript image

--- a/src/typescript-node/README.md
+++ b/src/typescript-node/README.md
@@ -9,7 +9,7 @@
 | *Categories* | Core, Languages |
 | *Image type* | Dockerfile |
 | *Published image* | mcr.microsoft.com/devcontainers/typescript-node |
-| *Available image variants* | 22 / 22-bookworm, 20 / 20-bookworm, 18 / 18-bookworm, 22-bullseye, 20-bullseye, 18-bullseye, 20-buster, 18-buster ([full list](https://mcr.microsoft.com/v2/devcontainers/typescript-node/tags/list)) |
+| *Available image variants* | 24 / 24-bookworm, 22 / 22-bookworm, 20 / 20-bookworm, 18 / 18-bookworm, 24-bullseye, 22-bullseye, 20-bullseye, 18-bullseye, 20-buster, 18-buster ([full list](https://mcr.microsoft.com/v2/devcontainers/typescript-node/tags/list)) |
 | *Published image architecture(s)* | x86-64, arm64/aarch64 for `bookworm`, and `bullseye` variants |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
@@ -20,19 +20,19 @@
 You can directly reference pre-built versions of `Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own  `Dockerfile` to one of the following. An example `Dockerfile` is included in this repository.
 
 - `mcr.microsoft.com/devcontainers/typescript-node` (latest)
+- `mcr.microsoft.com/devcontainers/typescript-node:24` (or `24-bookworm`, `24-bullseye` to pin to an OS version)
 - `mcr.microsoft.com/devcontainers/typescript-node:22` (or `22-bookworm`, `22-bullseye` to pin to an OS version)
 - `mcr.microsoft.com/devcontainers/typescript-node:20` (or `20-bookworm`, `20-bullseye`, `20-buster` to pin to an OS version)
-- `mcr.microsoft.com/devcontainers/typescript-node:18` (or `18-bookworm`, `18-bullseye`, `18-buster` to pin to an OS version)
 
 Refer to [this guide](https://containers.dev/guide/dockerfile) for more details.
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
-- `mcr.microsoft.com/devcontainers/typescript-node:1-22` (or `1-22-bookworm`, `1-22-bullseye`)
-- `mcr.microsoft.com/devcontainers/typescript-node:1.1-22` (or `1.1-22-bookworm`, `1.1-22-bullseye`)
-- `mcr.microsoft.com/devcontainers/typescript-node:1.1.0-22` (or `1.1.0-20-bookworm`, `1.1.0-20-bullseye`)
+- `mcr.microsoft.com/devcontainers/typescript-node:1-24` (or `1-24-bookworm`, `1-24-bullseye`)
+- `mcr.microsoft.com/devcontainers/typescript-node:1.1-24` (or `1.1-24-bookworm`, `1.1-24-bullseye`)
+- `mcr.microsoft.com/devcontainers/typescript-node:1.1.0-24` (or `1.1.0-24-bookworm`, `1.1.0-24-bullseye`)
 
-However, we only do security patching on the latest [non-breaking, in support](https://github.com/devcontainers/images/issues/90) versions of images (e.g. `1-1.20`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
+However, we only do security patching on the latest [non-breaking, in support](https://github.com/devcontainers/images/issues/90) versions of images (e.g. `1-24`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 
 Beyond TypeScript, Node.js, and `git`, this image / `Dockerfile` includes `eslint`, `zsh`, [Oh My Zsh!](https://ohmyz.sh/), a non-root `node` user with `sudo` access, and a set of common dependencies for development. Since `tslint` is [now fully deprecated](https://github.com/palantir/tslint/issues/4534), the image includes `tslint-to-eslint-config` globally to help you migrate.
 

--- a/src/typescript-node/manifest.json
+++ b/src/typescript-node/manifest.json
@@ -1,18 +1,24 @@
 {
 	"version": "1.1.12",
 	"variants": [
+		"24-bookworm",
 		"22-bookworm",
 		"20-bookworm",
 		"18-bookworm",
+		"24-bullseye",
 		"22-bullseye",
 		"20-bullseye",
 		"18-bullseye"
 	],
 	"build": {
-		"latest": "22-bookworm",
+		"latest": "24-bookworm",
 		"rootDistro": "debian",
 		"parent": "javascript-node",
 		"architectures": {
+			"24-bookworm": [
+				"linux/amd64",
+				"linux/arm64"
+			],
 			"22-bookworm": [
 				"linux/amd64",
 				"linux/arm64"
@@ -22,6 +28,10 @@
 				"linux/arm64"
 			],
 			"18-bookworm": [
+				"linux/amd64",
+				"linux/arm64"
+			],
+			"24-bullseye": [
 				"linux/amd64",
 				"linux/arm64"
 			],
@@ -42,15 +52,21 @@
 			"typescript-node:${VERSION}-${VARIANT}"
 		],
 		"variantTags": {
-			"22-bookworm": [
-				"typescript-node:${VERSION}-22",
+			"24-bookworm": [
+				"typescript-node:${VERSION}-24",
 				"typescript-node:${VERSION}-bookworm"
+			],
+			"22-bookworm": [
+				"typescript-node:${VERSION}-22"
 			],
 			"20-bookworm": [
 				"typescript-node:${VERSION}-20"
 			],
 			"18-bookworm": [
 				"typescript-node:${VERSION}-18"
+			],
+			"24-bullseye": [
+				"typescript-node:${VERSION}-bullseye"
 			],
 			"22-bullseye": [
 				"typescript-node:${VERSION}-bullseye"


### PR DESCRIPTION
## Summary by Sourcery

Add support for Node.js 24-based variants in both javascript-node and typescript-node images and bump the default variant to 24-bookworm

New Features:
- Introduce ‘24-bookworm’ and ‘24-bullseye’ variants for both javascript-node and typescript-node images

Enhancements:
- Set the latest default variant to 24-bookworm and define linux/amd64 and linux/arm64 architectures for the new variants
- Update variantTags in manifests to include 24-based tags
- Update .devcontainer Dockerfiles to default to VARIANT=24-bookworm

Documentation:
- Refresh READMEs to list the new 24 and 24-bullseye variants and update tag reference examples