### PR TITLE
Support: typescript-node 24

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1233,6 +1233,16 @@
                 "Type": "other",
                 "Other": {
                     "Name": "Docker Image: node",
+                    "Version": "24-bookworm",
+                    "DownloadUrl": "https://hub.docker.com/_/node"
+                }
+            }
+        },
+        {
+            "Component": {
+                "Type": "other",
+                "Other": {
+                    "Name": "Docker Image: node",
                     "Version": "22-bookworm",
                     "DownloadUrl": "https://hub.docker.com/_/node"
                 }
@@ -1254,6 +1264,16 @@
                 "Other": {
                     "Name": "Docker Image: node",
                     "Version": "18-bookworm",
+                    "DownloadUrl": "https://hub.docker.com/_/node"
+                }
+            }
+        },
+        {
+            "Component": {
+                "Type": "other",
+                "Other": {
+                    "Name": "Docker Image: node",
+                    "Version": "24-bullseye",
                     "DownloadUrl": "https://hub.docker.com/_/node"
                 }
             }

--- a/src/typescript-node/.devcontainer/Dockerfile
+++ b/src/typescript-node/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-ARG VARIANT=22-bookworm
-FROM mcr.microsoft.com/devcontainers/javascript-node:1-${VARIANT}
+ARG VARIANT=24-bookworm
+FROM mcr.microsoft.com/devcontainers/javascript-node:2-${VARIANT}
 
 # Install tslint, typescript. eslint is installed by javascript image
 ARG NODE_MODULES="tslint-to-eslint-config typescript"

--- a/src/typescript-node/README.md
+++ b/src/typescript-node/README.md
@@ -9,7 +9,7 @@
 | *Categories* | Core, Languages |
 | *Image type* | Dockerfile |
 | *Published image* | mcr.microsoft.com/devcontainers/typescript-node |
-| *Available image variants* | 22 / 22-bookworm, 20 / 20-bookworm, 22-bullseye, 20-bullseye ([full list](https://mcr.microsoft.com/v2/devcontainers/typescript-node/tags/list)) |
+| *Available image variants* | 24 / 24-bookworm, 22 / 22-bookworm, 20 / 20-bookworm, 24-bullseye, 22-bullseye, 20-bullseye ([full list](https://mcr.microsoft.com/v2/devcontainers/typescript-node/tags/list)) |
 | *Published image architecture(s)* | x86-64, arm64/aarch64 for `bookworm`, and `bullseye` variants |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
@@ -20,6 +20,7 @@
 You can directly reference pre-built versions of `Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own  `Dockerfile` to one of the following. An example `Dockerfile` is included in this repository.
 
 - `mcr.microsoft.com/devcontainers/typescript-node` (latest)
+- `mcr.microsoft.com/devcontainers/typescript-node:24` (or `24-bookworm`, `24-bullseye` to pin to an OS version)
 - `mcr.microsoft.com/devcontainers/typescript-node:22` (or `22-bookworm`, `22-bullseye` to pin to an OS version)
 - `mcr.microsoft.com/devcontainers/typescript-node:20` (or `20-bookworm`, `20-bullseye` to pin to an OS version)
 
@@ -27,11 +28,11 @@ Refer to [this guide](https://containers.dev/guide/dockerfile) for more details.
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
-- `mcr.microsoft.com/devcontainers/typescript-node:2-22` (or `2-22-bookworm`, `2-22-bullseye`)
-- `mcr.microsoft.com/devcontainers/typescript-node:2.0-22` (or `2.0-22-bookworm`, `2.0-22-bullseye`)
-- `mcr.microsoft.com/devcontainers/typescript-node:2.0.0-22` (or `2.0.0-22-bookworm`, `2.0.0-22-bullseye`)
+- `mcr.microsoft.com/devcontainers/typescript-node:2-24` (or `2-24-bookworm`, `2-24-bullseye`)
+- `mcr.microsoft.com/devcontainers/typescript-node:2.0-24` (or `2.0-24-bookworm`, `2.0-24-bullseye`)
+- `mcr.microsoft.com/devcontainers/typescript-node:2.0.0-24` (or `2.0.0-24-bookworm`, `2.0.0-24-bullseye`)
 
-However, we only do security patching on the latest [non-breaking, in support](https://github.com/devcontainers/images/issues/90) versions of images (e.g. `1-1.20`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
+However, we only do security patching on the latest [non-breaking, in support](https://github.com/devcontainers/images/issues/90) versions of images (e.g. `2-24`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 
 Beyond TypeScript, Node.js, and `git`, this image / `Dockerfile` includes `eslint`, `zsh`, [Oh My Zsh!](https://ohmyz.sh/), a non-root `node` user with `sudo` access, and a set of common dependencies for development. Since `tslint` is [now fully deprecated](https://github.com/palantir/tslint/issues/4534), the image includes `tslint-to-eslint-config` globally to help you migrate.
 

--- a/src/typescript-node/manifest.json
+++ b/src/typescript-node/manifest.json
@@ -1,21 +1,31 @@
 {
 	"version": "2.0.0",
 	"variants": [
+		"24-bookworm",
 		"22-bookworm",
 		"20-bookworm",
+		"24-bullseye",
 		"22-bullseye",
 		"20-bullseye"
 	],
 	"build": {
-		"latest": "22-bookworm",
+		"latest": "24-bookworm",
 		"rootDistro": "debian",
 		"parent": "javascript-node",
 		"architectures": {
+			"24-bookworm": [
+				"linux/amd64",
+				"linux/arm64"
+			],
 			"22-bookworm": [
 				"linux/amd64",
 				"linux/arm64"
 			],
 			"20-bookworm": [
+				"linux/amd64",
+				"linux/arm64"
+			],
+			"24-bullseye": [
 				"linux/amd64",
 				"linux/arm64"
 			],
@@ -32,17 +42,17 @@
 			"typescript-node:${VERSION}-${VARIANT}"
 		],
 		"variantTags": {
-			"22-bookworm": [
-				"typescript-node:${VERSION}-22",
+			"24-bookworm": [
+				"typescript-node:${VERSION}-24",
 				"typescript-node:${VERSION}-bookworm"
+			],
+			"22-bookworm": [
+				"typescript-node:${VERSION}-22"
 			],
 			"20-bookworm": [
 				"typescript-node:${VERSION}-20"
 			],
-			"22-bullseye": [
-				"typescript-node:${VERSION}-bullseye"
-			],
-			"20-bullseye": [
+			"24-bullseye": [
 				"typescript-node:${VERSION}-bullseye"
 			]
 		}


### PR DESCRIPTION
## Summary by Sourcery

Add support for TypeScript-Node 24 images and make them the new default variant, updating the manifest, default Dockerfile, and documentation accordingly.

New Features:
- Introduce TypeScript-Node 24 image variants for both Debian bookworm and bullseye.

Enhancements:
- Promote 24-bookworm as the latest default variant.
- Bump default .devcontainer Dockerfile to use the 24-bookworm variant and JavaScript-Node v2 base.

Build:
- Add 24-bookworm and 24-bullseye to supported variants, architectures, and variantTags in the manifest.

Documentation:
- Update README to list 24 variants and corresponding example image tags.